### PR TITLE
Missing plugin when creating Debian packages

### DIFF
--- a/setup_common.py
+++ b/setup_common.py
@@ -44,7 +44,7 @@ PackageData = {
 
 exclude = ['quantum.client', 'quantum.client.*', 'quantum.server',
     'quantum.server.*', 'quantum.tests', 'quantum.tests.*',
-    'quantum.plugins.*', 'quantum.plugins']
+    'quantum.plugins.*']
 pkgs = find_packages('.', exclude=exclude)
 pkgs = filter(lambda x: x.startswith("quantum"), pkgs)
 


### PR DESCRIPTION
Hi,

I'm using debian building scripts to package Quantum and I was getting this error:
('Inner Exception: %s', ImportError('No module named plugins.sample.SamplePlugin',))

I noticed that none of the setup_*.py copy the **init**.py from the plugins, so I added in the common setup and now it's working perfect.

Is this the right way to do it ?

Here goes the diff patch.

Thanks
