### PR TITLE
decrement rules_index if we encounter duplicate chains

### DIFF
--- a/neutron/agent/linux/iptables_manager.py
+++ b/neutron/agent/linux/iptables_manager.py
@@ -474,6 +474,8 @@ class IptablesManager(object):
                 # grab the last entry, if there is one
                 dup = dup_filter[-1]
                 chain_str = str(dup).strip()
+                # backup one index so we write the array correctly
+                rules_index -= 1
             else:
                 # add-on the [packet:bytes]
                 chain_str += ' - [0:0]'


### PR DESCRIPTION
decrement rules_index when we encounter a duplicate chain. if we don't do this and a duplicate chain name is found then the rules will be inserted into the wrong place which can cause iptables-restore to fail to parse the new rule set.
