### PR TITLE
Add default route to classless routes

### DIFF
--- a/neutron/agent/linux/dhcp.py
+++ b/neutron/agent/linux/dhcp.py
@@ -544,6 +544,9 @@ class Dnsmasq(DhcpLocalProcess):
                 )
 
             if host_routes:
+                if gateway:
+                    host_routes.append('0.0.0.0/0,%s' % (gateway))
+
                 options.append(
                     self._format_option(i, 'classless-static-route',
                                         ','.join(host_routes)))


### PR DESCRIPTION
According to https://tools.ietf.org/html/rfc3442 static routes have to include the default gw:

> If the DHCP server returns both a Classless Static Routes option and a Router option, the DHCP client MUST ignore the Router option.

This patch adds the default gw to the classless static route if one is defined.
