### PR TITLE
Typo in test name

### DIFF
--- a/neutron/tests/unit/common/test_utils.py
+++ b/neutron/tests/unit/common/test_utils.py
@@ -636,7 +636,7 @@ class TestIpVersionFromInt(base.BaseTestCase):
                           8)
 
 
-class TestDelayedStringRederer(base.BaseTestCase):
+class TestDelayedStringRenderer(base.BaseTestCase):
     def test_call_deferred_until_str(self):
         my_func = mock.MagicMock(return_value='Brie cheese!')
         delayed = utils.DelayedStringRenderer(my_func, 1, 2, key_arg=44)


### PR DESCRIPTION
Not very interesting change: typo "Rederer" => "Renderer"