### PR TITLE
refactor:  convert `float` to `int`

### DIFF
--- a/neutron/plugins/ml2/drivers/agent/_common_agent.py
+++ b/neutron/plugins/ml2/drivers/agent/_common_agent.py
@@ -433,7 +433,7 @@ class CommonAgentLoop(service.Service):
         sync = True
 
         while True:
-            start = time.time()
+            start = int(time.time())
 
             if self.fullsync:
                 sync = True
@@ -457,7 +457,7 @@ class CommonAgentLoop(service.Service):
                     sync = True
 
             # sleep till end of polling interval
-            elapsed = (time.time() - start)
+            elapsed = (int(time.time()) - start)
             if (elapsed < self.polling_interval):
                 time.sleep(self.polling_interval - elapsed)
             else:


### PR DESCRIPTION
It's not recommend to calculate between float. For instance:

Python 2.7.10 (default, Oct 23 2015, 19:19:21)
[GCC 4.2.1 Compatible Apple LLVM 7.0.0 (clang-700.0.59.5)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> 0.1 + 0.2
0.30000000000000004
>>> 0.2 - 0.1
0.1
>>> 0.3 - 0.1
0.19999999999999998
>>> 0.1 + 0.3
0.4
>>> 0.1 + 0.2
0.30000000000000004ommit message for your changes. Lines starting